### PR TITLE
auto check for broken links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,12 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          max-depth: 2


### PR DESCRIPTION
Added a [bot](https://github.com/gaurav-nelson/github-action-markdown-link-check) to automatically check for broken links. Every time there is a push to the repository, the bot will run.